### PR TITLE
Rollback migration in reverse order

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -39,7 +39,7 @@ module ActualDbSchema
   # Add new command to roll back the phantom migrations
   module MigrationContextPatch
     def rollback_branches
-      migrations.each do |migration|
+      migrations.reverse_each do |migration|
         migrator = down_migrator_for(migration)
         migrator.extend(ActualDbSchema::MigratorPatch)
         migrator.migrate


### PR DESCRIPTION
Hey @ka8725, thanks for a great gem!

Normally migrations are run in direct order and later migrations sometimes depend on the earlier ones, so we have roll them back in reversed order.