### PR TITLE
Phantom migrations status rake task

### DIFF
--- a/lib/actual_db_schema.rb
+++ b/lib/actual_db_schema.rb
@@ -6,6 +6,7 @@ require_relative "actual_db_schema/patches/migration_proxy"
 require_relative "actual_db_schema/patches/migrator"
 require_relative "actual_db_schema/patches/migration_context"
 
+require_relative "actual_db_schema/commands/base"
 require_relative "actual_db_schema/commands/rollback"
 require_relative "actual_db_schema/commands/list"
 

--- a/lib/actual_db_schema.rb
+++ b/lib/actual_db_schema.rb
@@ -6,6 +6,9 @@ require_relative "actual_db_schema/patches/migration_proxy"
 require_relative "actual_db_schema/patches/migrator"
 require_relative "actual_db_schema/patches/migration_context"
 
+require_relative "actual_db_schema/commands/rollback"
+require_relative "actual_db_schema/commands/list"
+
 # The main module definition
 module ActualDbSchema
   raise NotImplementedError, "ActualDbSchema is only supported in Rails" unless defined?(Rails)

--- a/lib/actual_db_schema/commands/base.rb
+++ b/lib/actual_db_schema/commands/base.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module ActualDbSchema
+  module Commands
+    # Base class for all commands
+    class Base
+      def call
+        unless ActualDbSchema.config.fetch(:enabled, true)
+          raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
+        end
+
+        if ActiveRecord::Migration.current_version >= 6
+          ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:rollback_branches")
+        end
+
+        call_impl
+      end
+
+      private
+
+      def call_impl
+        raise NotImplementedError
+      end
+
+      def context
+        @context ||=
+          ActiveRecord::Base.connection.migration_context.tap do |c|
+            c.extend(ActualDbSchema::Patches::MigrationContext)
+          end
+      end
+    end
+  end
+end

--- a/lib/actual_db_schema/commands/list.rb
+++ b/lib/actual_db_schema/commands/list.rb
@@ -1,25 +1,32 @@
+# frozen_string_literal: true
+
 module ActualDbSchema
   module Commands
+    # Shows the list of phantom migrations
     class List
-      def call
-        unless ActualDbSchema.config.fetch(:enabled, true)
-          raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
-        end
+      private
 
-        context = ActiveRecord::Base.connection.migration_context
-        context.extend(ActualDbSchema::Patches::MigrationContext)
+      def call_impl
+        preambule
+        table
+      end
 
+      def indexed_phantom_migrations
+        @indexed_phantom_migrations ||= context.migrations.index_by { |m| m.version.to_s }
+      end
+
+      def preambule
         puts "\nPhantom migrations\n\n"
         puts "Below is a list of irrelevant migrations executed in unmerged branches."
         puts "To bring your database schema up to date, the migrations marked as \"up\" should be rolled back."
         puts "\ndatabase: #{ActiveRecord::Base.connection_db_config.database}\n\n"
         puts %(#{"Status".center(8)}  #{"Migration ID".ljust(14)}  Migration File)
         puts "-" * 50
+      end
 
-        phantom_migrations = context.migrations.index_by { |m| m.version.to_s }
-
+      def table
         context.migrations_status.each do |status, version|
-          migration = phantom_migrations[version]
+          migration = indexed_phantom_migrations[version]
           next unless migration
 
           puts %(#{status.center(8)}  #{version.to_s.ljust(14)}  #{migration.filename.gsub("#{Rails.root}/", "")})

--- a/lib/actual_db_schema/commands/list.rb
+++ b/lib/actual_db_schema/commands/list.rb
@@ -1,0 +1,30 @@
+module ActualDbSchema
+  module Commands
+    class List
+      def call
+        unless ActualDbSchema.config.fetch(:enabled, true)
+          raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
+        end
+
+        context = ActiveRecord::Base.connection.migration_context
+        context.extend(ActualDbSchema::Patches::MigrationContext)
+
+        puts "\nPhantom migrations\n\n"
+        puts "Below is a list of irrelevant migrations executed in unmerged branches."
+        puts "To bring your database schema up to date, the migrations marked as \"up\" should be rolled back."
+        puts "\ndatabase: #{ActiveRecord::Base.connection_db_config.database}\n\n"
+        puts %(#{"Status".center(8)}  #{"Migration ID".ljust(14)}  Migration File)
+        puts "-" * 50
+
+        phantom_migrations = context.migrations.index_by { |m| m.version.to_s }
+
+        context.migrations_status.each do |status, version|
+          migration = phantom_migrations[version]
+          next unless migration
+
+          puts %(#{status.center(8)}  #{version.to_s.ljust(14)}  #{migration.filename.gsub("#{Rails.root}/", "")})
+        end
+      end
+    end
+  end
+end

--- a/lib/actual_db_schema/commands/list.rb
+++ b/lib/actual_db_schema/commands/list.rb
@@ -3,7 +3,7 @@
 module ActualDbSchema
   module Commands
     # Shows the list of phantom migrations
-    class List
+    class List < Base
       private
 
       def call_impl

--- a/lib/actual_db_schema/commands/rollback.rb
+++ b/lib/actual_db_schema/commands/rollback.rb
@@ -1,0 +1,26 @@
+module ActualDbSchema
+  module Commands
+    class Rollback
+      def call
+        unless ActualDbSchema.config.fetch(:enabled, true)
+          raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
+        end
+
+        if ActiveRecord::Migration.current_version >= 6
+          ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:rollback_branches")
+        end
+
+        context = ActiveRecord::Base.connection.migration_context
+        context.extend(ActualDbSchema::Patches::MigrationContext)
+        context.rollback_branches
+        if ActualDbSchema.failed.any?
+          puts ""
+          puts "[ActualDbSchema] Irreversible migrations were found from other branches. Roll them back or fix manually:"
+          puts ""
+          puts ActualDbSchema.failed.map { |migration| "- #{migration.filename}" }.join("\n")
+          puts ""
+        end
+      end
+    end
+  end
+end

--- a/lib/actual_db_schema/commands/rollback.rb
+++ b/lib/actual_db_schema/commands/rollback.rb
@@ -1,25 +1,21 @@
+# frozen_string_literal: true
+
 module ActualDbSchema
   module Commands
+    # Rolls back all phantom migrations
     class Rollback
-      def call
-        unless ActualDbSchema.config.fetch(:enabled, true)
-          raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
-        end
+      private
 
-        if ActiveRecord::Migration.current_version >= 6
-          ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:rollback_branches")
-        end
-
-        context = ActiveRecord::Base.connection.migration_context
-        context.extend(ActualDbSchema::Patches::MigrationContext)
+      def call_impl
         context.rollback_branches
-        if ActualDbSchema.failed.any?
-          puts ""
-          puts "[ActualDbSchema] Irreversible migrations were found from other branches. Roll them back or fix manually:"
-          puts ""
-          puts ActualDbSchema.failed.map { |migration| "- #{migration.filename}" }.join("\n")
-          puts ""
-        end
+
+        return if ActualDbSchema.failed.empty?
+
+        puts ""
+        puts "[ActualDbSchema] Irreversible migrations were found from other branches. Roll them back or fix manually:"
+        puts ""
+        puts ActualDbSchema.failed.map { |migration| "- #{migration.filename}" }.join("\n")
+        puts ""
       end
     end
   end

--- a/lib/actual_db_schema/commands/rollback.rb
+++ b/lib/actual_db_schema/commands/rollback.rb
@@ -3,7 +3,7 @@
 module ActualDbSchema
   module Commands
     # Rolls back all phantom migrations
-    class Rollback
+    class Rollback < Base
       private
 
       def call_impl

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -23,5 +23,24 @@ namespace :db do
     end
   end
 
+  desc "List all phantom migrations - non-relevant migrations that were run inside not a merged branch."
+  task phantom_migrations: :load_config do
+    unless ActualDbSchema.config.fetch(:enabled, true)
+      raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
+    end
+
+    context = ActiveRecord::Base.connection.migration_context
+    context.extend(ActualDbSchema::Patches::MigrationContext)
+
+    puts "\nPhantom migrations\n\n"
+    puts "The following is a list of non-relevant migrations that were run inside a branch that has not been merged."
+    puts "\ndatabase: #{ActiveRecord::Base.connection_db_config.database}\n\n"
+    puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
+    puts "-" * 50
+    context.migrations.each do |migration|
+      puts "#{'up'.center(8)}  #{migration.version.to_s.ljust(14)}  #{migration.filename.gsub(Rails.root.to_s + "/", "")}"
+    end
+  end
+
   task _dump: :rollback_branches
 end

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -3,43 +3,12 @@
 namespace :db do
   desc "Rollback migrations that were run inside not a merged branch."
   task rollback_branches: :load_config do
-    unless ActualDbSchema.config.fetch(:enabled, true)
-      raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
-    end
-
-    if ActiveRecord::Migration.current_version >= 6
-      ActiveRecord::Tasks::DatabaseTasks.raise_for_multi_db(command: "db:rollback_branches")
-    end
-
-    context = ActiveRecord::Base.connection.migration_context
-    context.extend(ActualDbSchema::Patches::MigrationContext)
-    context.rollback_branches
-    if ActualDbSchema.failed.any?
-      puts ""
-      puts "[ActualDbSchema] Irreversible migrations were found from other branches. Roll them back or fix manually:"
-      puts ""
-      puts ActualDbSchema.failed.map { |migration| "- #{migration.filename}" }.join("\n")
-      puts ""
-    end
+    ActualDbSchema::Commands::Rollback.new.call
   end
 
   desc "List all phantom migrations - non-relevant migrations that were run inside not a merged branch."
   task phantom_migrations: :load_config do
-    unless ActualDbSchema.config.fetch(:enabled, true)
-      raise "ActualDbSchema is disabled. Set ActualDbSchema.config[:enabled] = true to enable it."
-    end
-
-    context = ActiveRecord::Base.connection.migration_context
-    context.extend(ActualDbSchema::Patches::MigrationContext)
-
-    puts "\nPhantom migrations\n\n"
-    puts "The following is a list of non-relevant migrations that were run inside a branch that has not been merged."
-    puts "\ndatabase: #{ActiveRecord::Base.connection_db_config.database}\n\n"
-    puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
-    puts "-" * 50
-    context.migrations.each do |migration|
-      puts "#{'up'.center(8)}  #{migration.version.to_s.ljust(14)}  #{migration.filename.gsub(Rails.root.to_s + "/", "")}"
-    end
+    ActualDbSchema::Commands::List.new.call
   end
 
   task _dump: :rollback_branches

--- a/test/dummy_app/db/schema.rb
+++ b/test/dummy_app/db/schema.rb
@@ -10,5 +10,5 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[6.0].define(version: 0) do
+ActiveRecord::Schema[7.1].define(version: 0) do
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,3 +25,26 @@ ActiveRecord::Tasks::DatabaseTasks.database_configuration = { test: db_config }
 ActiveRecord::Base.establish_connection(**db_config)
 
 ActualDbSchema.config[:enabled] = true
+
+class TestingState
+  class << self
+    attr_accessor :up, :down, :output
+  end
+
+  def self.reset
+    self.up = []
+    self.down = []
+    self.output = +""
+  end
+
+  reset
+end
+
+module Kernel
+  alias original_puts puts
+
+  def puts(*args)
+    TestingState.output << args.join("\n")
+    original_puts(*args)
+  end
+end


### PR DESCRIPTION
Closes #34 


Add a rake task that shows a list of all phantom migrations along with their statuses. This is a preparation step for cleaning the branches manually.

<img width="698" alt="image" src="https://github.com/widefix/actual_db_schema/assets/243846/097e5530-a39f-43bd-8f3a-8d71db10d019">
