### PR TITLE
Add support for older rails versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     actual_db_schema (0.7.6)
-      activerecord (>= 6.0.0)
-      activesupport (>= 6.0.0)
+      activerecord
+      activesupport
       csv
 
 GEM

--- a/actual_db_schema.gemspec
+++ b/actual_db_schema.gemspec
@@ -35,8 +35,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   # Uncomment to register a new dependency of your gem
-  spec.add_runtime_dependency "activerecord", ">= 6.0.0"
-  spec.add_runtime_dependency "activesupport", ">= 6.0.0"
+  spec.add_runtime_dependency "activerecord"
+  spec.add_runtime_dependency "activesupport"
   spec.add_runtime_dependency "csv"
 
   spec.add_development_dependency "appraisal"

--- a/lib/actual_db_schema/migration_context.rb
+++ b/lib/actual_db_schema/migration_context.rb
@@ -20,7 +20,12 @@ module ActualDbSchema
     end
 
     def configs
-      ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
+      # Rails < 6.0 has a Hash in configurations
+      if ActiveRecord::Base.configurations.is_a?(Hash)
+        [ActiveRecord::Base.configurations[ActiveRecord::Tasks::DatabaseTasks.env]]
+      else
+        ActiveRecord::Base.configurations.configs_for(env_name: ActiveRecord::Tasks::DatabaseTasks.env)
+      end
     end
 
     def context


### PR DESCRIPTION
This PR is adding support for older Rails versions than 6.0. Even though there are no tests and those are not officially supported, it's still worth using this gem for them. It's up to users how to use it and fix it if needed.