### PR TITLE
[issue-45] Make rollback more informative

### DIFF
--- a/lib/actual_db_schema/patches/migration_context.rb
+++ b/lib/actual_db_schema/patches/migration_context.rb
@@ -74,6 +74,7 @@ module ActualDbSchema
       def migrate(migration)
         migrator = down_migrator_for(migration)
         migrator.extend(ActualDbSchema::Patches::Migrator)
+        puts "\n\e[32m[ActualDbSchema] is initiating a rollback of the migration below:\e[0m"
         migrator.migrate
       end
 

--- a/test/rake_task_secondary_test.rb
+++ b/test/rake_task_secondary_test.rb
@@ -37,6 +37,8 @@ describe "second db support" do
       utils.prepare_phantom_migrations
       assert_empty TestingState.down
       utils.run_migrations
+      assert_match(/\e\[32m\[ActualDbSchema\] is initiating a rollback of the migration below:\e\[0m/,
+                   TestingState.output)
       assert_equal %i[second first], TestingState.down
     end
 

--- a/test/rake_task_test.rb
+++ b/test/rake_task_test.rb
@@ -35,6 +35,8 @@ describe "single db" do
       utils.prepare_phantom_migrations
       assert_empty TestingState.down
       utils.run_migrations
+      assert_match(/\e\[32m\[ActualDbSchema\] is initiating a rollback of the migration below:\e\[0m/,
+                   TestingState.output)
       assert_equal %i[second first], TestingState.down
     end
 

--- a/test/rake_tasks_all_databases_test.rb
+++ b/test/rake_tasks_all_databases_test.rb
@@ -52,6 +52,8 @@ describe "multipe db support" do
       utils.prepare_phantom_migrations(TestingState.db_config)
       assert_empty TestingState.down
       utils.run_migrations
+      assert_match(/\e\[32m\[ActualDbSchema\] is initiating a rollback of the migration below:\e\[0m/,
+                   TestingState.output)
       assert_equal %i[second_primary first_primary second_secondary first_secondary], TestingState.down
     end
 


### PR DESCRIPTION
When the phantom migration is being rolled back there should be a comment to show that to the user.