### PR TITLE
feat: add more detailed information to the rollback output

### DIFF
--- a/lib/actual_db_schema/commands/rollback.rb
+++ b/lib/actual_db_schema/commands/rollback.rb
@@ -18,15 +18,48 @@ module ActualDbSchema
       private
 
       def call_impl
-        context.rollback_branches(manual_mode: @manual_mode)
-
-        return if ActualDbSchema.failed.empty?
+        phantom_migrations = context.rollback_branches(manual_mode: @manual_mode)
+        successfully_rolled_back = filter_successful_migrations(phantom_migrations)
+        return if phantom_migrations.empty?
 
         puts_preamble
-        puts_into
+        puts_intro_info
+        puts_successful_rollback_info(successfully_rolled_back) unless successfully_rolled_back.empty?
+        puts_unsuccessful_rollback_info unless ActualDbSchema.failed.empty?
+        puts_preamble
+      end
+
+      def filter_successful_migrations(phantom_migrations)
+        phantom_migrations.reject { |migration| ActualDbSchema.failed.map(&:migration).include?(migration) }
+      end
+
+      def puts_successful_rollback_info(list)
+        msg = "#{list.count} phantom #{"migration".pluralize(list.count)} were successfully rolled back."
+
+        puts colorize(msg, :green)
+        puts ""
+        puts successful_rollback_list(list)
+        puts ""
+      end
+
+      def successful_rollback_list(list)
+        list.map.with_index(1) do |migration, index|
+          filename = migration.filename.sub(File.join(Rails.root, "/"), "")
+          <<~MSG
+            \t#{colorize("[Migration##{index}]", :green)}
+            \t- #{filename}
+          MSG
+        end
+      end
+
+      def puts_unsuccessful_rollback_info
+        failed_rollback_count = ActualDbSchema.failed.count
+        msg = "#{failed_rollback_count} phantom #{"migration".pluralize(failed_rollback_count)} could not " \
+              "be rolled back automatically. Roll them back or fix manually:"
+        puts colorize(msg, :red)
         puts ""
         puts failed_migrations_list
-        puts_preamble
+        puts ""
       end
 
       def failed_migrations_list
@@ -42,16 +75,15 @@ module ActualDbSchema
         end
       end
 
+      def puts_intro_info
+        msg = "Phantom migrations were detected and actual_db_schema attempted to automatically roll them back.\n"
+        puts colorize(msg, :yellow)
+      end
+
       def puts_preamble
         puts ""
         puts %(\u2757\u2757\u2757 #{colorize("[ActualDbSchema]", :red)})
         puts ""
-      end
-
-      def puts_into
-        msg = "#{ActualDbSchema.failed.count} phantom migration(s) could not be rolled back automatically."
-        msg += " Roll them back or fix manually:"
-        puts colorize(msg, :red)
       end
 
       def manual_mode_default?

--- a/test/rake_task_test.rb
+++ b/test/rake_task_test.rb
@@ -83,7 +83,7 @@ describe "single db" do
         assert_empty ActualDbSchema.failed
         utils.run_migrations
         assert_equal(%w[20130906111510_irreversible.rb], ActualDbSchema.failed.map { |m| File.basename(m.filename) })
-        assert_match(/1 phantom migration\(s\) could not be rolled back automatically/, TestingState.output)
+        assert_match(/1 phantom migration could not be rolled back automatically/, TestingState.output)
       end
     end
   end


### PR DESCRIPTION
https://github.com/widefix/actual_db_schema/issues/45

This PR adds more information to the rollback message output displayed to the user. 
Previously we were only showing the list of migrations that were not successfully rolled back but this PR includes the list of successfully rolled back migrations if any and also informs the user of the reason for the attempted rollback of migrations by the gem.
![actual_db_schema](https://github.com/user-attachments/assets/3bb3ae63-2401-4a23-ae8d-53342484724a)
