### PR TITLE
Add Missing SQLite3 Dependencies to Fix CI Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rails.${{ matrix.rails }}.gemfile
     steps:
     - uses: actions/checkout@v2
+    - name: Install SQLite3 Development Libraries
+      run: sudo apt-get update && sudo apt-get install -y libsqlite3-dev
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
### Description

GitHub Actions recently [updated ubuntu-latest to use the Ubuntu 24.04 image](https://github.com/actions/runner-images/issues/10636), which no longer includes the `libsqlite3-dev` package by default. This package is required to build the `sqlite3` gem.
This PR updates the workflow file to explicitly install the SQLite3 development libraries in the CI environment.