### PR TITLE
Fix phantom migration rollback failures caused by cross-branch acronyms

### DIFF
--- a/lib/actual_db_schema/patches/migration_context.rb
+++ b/lib/actual_db_schema/patches/migration_context.rb
@@ -79,6 +79,8 @@ module ActualDbSchema
       end
 
       def migrate(migration)
+        migration.name = extract_class_name(migration.filename)
+
         message = "[ActualDbSchema] Rolling back phantom migration #{migration.version} #{migration.name} " \
             "(from branch: #{branch_for(migration.version.to_s)})"
         puts colorize(message, :gray)
@@ -87,6 +89,11 @@ module ActualDbSchema
         migrator.extend(ActualDbSchema::Patches::Migrator)
         migrator.migrate
         File.delete(migration.filename)
+      end
+
+      def extract_class_name(filename)
+        content = File.read(filename)
+        content.match(/^class\s+([A-Za-z0-9_]+)\s+</)[1]
       end
 
       def branch_for(version)

--- a/test/support/test_utils.rb
+++ b/test/support/test_utils.rb
@@ -144,6 +144,12 @@ class TestUtils
     metadata.fetch(version.to_s, {})[:branch]
   end
 
+  def define_acronym(acronym)
+    ActiveSupport::Inflector.inflections(:en) do |inflect|
+      inflect.acronym acronym
+    end
+  end
+
   private
 
   def cleanup_call(prefix_name = nil)


### PR DESCRIPTION
Closes https://github.com/widefix/actual_db_schema/issues/95

### Description
Phantom migration rollbacks were failing due to differences in acronym-inflection settings between branches. Rails relies on the current environment's inflector to derive class names from migration file names, leading to a mismatch when acronyms are defined inconsistently across branches.

To resolve this, the migration class name is now directly extracted from the migration file instead of relying on Rails' inflection logic. This ensures accurate class loading and successful rollbacks regardless of acronym definitions in other branches.