### PR TITLE
Add multi-tenancy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,20 @@ This task will prompt you to choose one of the three options:
 
 Based on your selection, a post-checkout hook will be installed or updated in your `.git/hooks` folder.
 
+## Multi-Tenancy Support
+
+If your application leverages multiple schemas for multi-tenancy — such as those implemented by the [apartment](https://github.com/influitive/apartment) gem or similar solutions — you can configure ActualDbSchema to handle migrations across all schemas. To do so, add the following configuration to your initializer file (`config/initializers/actual_db_schema.rb`):
+
+```ruby
+ActualDbSchema.config[:multi_tenant_schemas] = -> { # list of all active schemas }
+```
+
+### Example:
+
+```ruby
+ActualDbSchema.config[:multi_tenant_schemas] = -> { ["public", "tenant1", "tenant2"] }
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/actual_db_schema.rb
+++ b/lib/actual_db_schema.rb
@@ -14,6 +14,7 @@ require_relative "actual_db_schema/patches/migration_proxy"
 require_relative "actual_db_schema/patches/migrator"
 require_relative "actual_db_schema/patches/migration_context"
 require_relative "actual_db_schema/git_hooks"
+require_relative "actual_db_schema/multi_tenant"
 
 require_relative "actual_db_schema/commands/base"
 require_relative "actual_db_schema/commands/rollback"

--- a/lib/actual_db_schema/failed_migration.rb
+++ b/lib/actual_db_schema/failed_migration.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ActualDbSchema
-  FailedMigration = Struct.new(:migration, :exception, :branch, keyword_init: true) do
+  FailedMigration = Struct.new(:migration, :exception, :branch, :schema, keyword_init: true) do
     def filename
       migration.filename
     end

--- a/lib/actual_db_schema/multi_tenant.rb
+++ b/lib/actual_db_schema/multi_tenant.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module ActualDbSchema
+  # Handles multi-tenancy support by switching schemas for supported databases
+  module MultiTenant
+    include ActualDbSchema::OutputFormatter
+
+    class << self
+      def with_schema(schema_name)
+        context = switch_schema(schema_name)
+        yield
+      ensure
+        restore_context(context)
+      end
+
+      private
+
+      def adapter_name
+        ActiveRecord::Base.connection.adapter_name
+      end
+
+      def switch_schema(schema_name)
+        case adapter_name
+        when /postgresql/i
+          switch_postgresql_schema(schema_name)
+        when /mysql/i
+          switch_mysql_schema(schema_name)
+        else
+          message = "[ActualDbSchema] Multi-tenancy not supported for adapter: #{adapter_name}. " \
+            "Proceeding without schema switching."
+          puts colorize(message, :gray)
+        end
+      end
+
+      def switch_postgresql_schema(schema_name)
+        old_search_path = ActiveRecord::Base.connection.schema_search_path
+        ActiveRecord::Base.connection.schema_search_path = schema_name
+        { type: :postgresql, old_context: old_search_path }
+      end
+
+      def switch_mysql_schema(schema_name)
+        old_db = ActiveRecord::Base.connection.current_database
+        ActiveRecord::Base.connection.execute("USE #{ActiveRecord::Base.connection.quote_table_name(schema_name)}")
+        { type: :mysql, old_context: old_db }
+      end
+
+      def restore_context(context)
+        return unless context
+
+        case context[:type]
+        when :postgresql
+          ActiveRecord::Base.connection.schema_search_path = context[:old_context] if context[:old_context]
+        when :mysql
+          return unless context[:old_context]
+
+          ActiveRecord::Base.connection.execute(
+            "USE #{ActiveRecord::Base.connection.quote_table_name(context[:old_context])}"
+          )
+        end
+      end
+    end
+  end
+end

--- a/test/rake_task_multi_tenant_test.rb
+++ b/test/rake_task_multi_tenant_test.rb
@@ -1,0 +1,169 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "multi-tenant db support" do
+  let(:utils) { TestUtils.new }
+
+  before do
+    skip "Skipping multi-tenant tests for sqlite3" if TestingState.db_config["primary"]["adapter"] == "sqlite3"
+
+    utils.reset_database_yml(TestingState.db_config["primary"])
+    ActiveRecord::Base.configurations = { "test" => TestingState.db_config["primary"] }
+    ActiveRecord::Tasks::DatabaseTasks.database_configuration = { "test" => TestingState.db_config["primary"] }
+    ActiveRecord::Base.establish_connection(**TestingState.db_config["primary"])
+
+    if ActiveRecord::Base.connection.adapter_name =~ /postgresql/i
+      ActiveRecord::Base.connection.execute("CREATE SCHEMA IF NOT EXISTS tenant1")
+      ActualDbSchema.config[:multi_tenant_schemas] = -> { %w[public tenant1] }
+    elsif ActiveRecord::Base.connection.adapter_name =~ /mysql/i
+      ActiveRecord::Base.connection.execute("CREATE DATABASE IF NOT EXISTS tenant1")
+      ActualDbSchema.config[:multi_tenant_schemas] = -> { [TestingState.db_config["primary"]["database"], "tenant1"] }
+    end
+
+    utils.cleanup
+  end
+
+  after do
+    if ActiveRecord::Base.connection.adapter_name =~ /postgresql/i
+      ActiveRecord::Base.connection.execute("DROP SCHEMA IF EXISTS tenant1 CASCADE")
+    elsif ActiveRecord::Base.connection.adapter_name =~ /mysql/i
+      ActiveRecord::Base.connection.execute("DROP DATABASE IF EXISTS tenant1")
+    end
+
+    ActualDbSchema.config[:multi_tenant_schemas] = nil
+  end
+
+  describe "db:rollback_branches" do
+    it "creates the tmp/migrated folder" do
+      refute File.exist?(utils.app_file("tmp/migrated"))
+      utils.run_migrations
+      assert File.exist?(utils.app_file("tmp/migrated"))
+    end
+
+    it "migrates the migrations" do
+      assert_empty utils.applied_migrations
+      utils.run_migrations
+      assert_equal %w[20130906111511 20130906111512], utils.applied_migrations
+    end
+
+    it "keeps migrated migrations in tmp/migrated folder" do
+      utils.run_migrations
+      assert_equal %w[20130906111511_first.rb 20130906111512_second.rb], utils.migrated_files
+    end
+
+    it "rolls back phantom migrations both in public (or primary) schema and tenant1" do
+      utils.prepare_phantom_migrations
+      assert_empty TestingState.down
+      utils.run_migrations
+      assert_equal %i[second first second first], TestingState.down
+      primary_schema = {
+        "postgresql" => "public",
+        "mysql2" => TestingState.db_config["primary"]["database"]
+      }.fetch(TestingState.db_config["primary"]["adapter"])
+      assert_match(/\[ActualDbSchema\] #{primary_schema}: Rolling back phantom migration/, TestingState.output)
+      assert_match(/\[ActualDbSchema\] tenant1: Rolling back phantom migration/, TestingState.output)
+      assert_empty utils.migrated_files
+    end
+  end
+
+  describe "with irreversible migration" do
+    before do
+      utils.define_migration_file("20130906111513_irreversible.rb", <<~RUBY)
+        class Irreversible < ActiveRecord::Migration[6.0]
+          def up
+            TestingState.up << :irreversible
+          end
+
+          def down
+            raise ActiveRecord::IrreversibleMigration
+          end
+        end
+      RUBY
+    end
+
+    it "keeps track of the irreversible migrations" do
+      utils.prepare_phantom_migrations
+      assert_equal %i[first second irreversible first second irreversible], TestingState.up
+      assert_empty ActualDbSchema.failed
+      utils.run_migrations
+      failed = ActualDbSchema.failed.map { |m| File.basename(m.filename) }
+      assert_equal(%w[20130906111513_irreversible.rb 20130906111513_irreversible.rb], failed)
+      assert_equal %w[20130906111513_irreversible.rb], utils.migrated_files
+    end
+  end
+
+  describe "db:rollback_branches:manual" do
+    it "rolls back phantom migrations both in public (or primary) schema and tenant1" do
+      utils.prepare_phantom_migrations
+      assert_equal %i[first second first second], TestingState.up
+      assert_empty TestingState.down
+      assert_empty ActualDbSchema.failed
+      utils.simulate_input("y") do
+        Rake::Task["db:rollback_branches:manual"].invoke
+        Rake::Task["db:rollback_branches:manual"].reenable
+      end
+      assert_equal %i[second first second first], TestingState.down
+      assert_empty utils.migrated_files
+    end
+
+    it "skips migrations if the input is 'n'" do
+      utils.prepare_phantom_migrations
+      assert_equal %i[first second first second], TestingState.up
+      assert_empty TestingState.down
+      assert_empty ActualDbSchema.failed
+
+      utils.simulate_input("n") do
+        Rake::Task["db:rollback_branches:manual"].invoke
+        Rake::Task["db:rollback_branches:manual"].reenable
+      end
+      assert_empty TestingState.down
+      assert_equal %i[first second first second], TestingState.up
+      assert_equal %w[20130906111511_first.rb 20130906111512_second.rb], utils.migrated_files
+    end
+
+    describe "with irreversible migration" do
+      before do
+        utils.define_migration_file("20130906111513_irreversible.rb", <<~RUBY)
+          class Irreversible < ActiveRecord::Migration[6.0]
+            def up
+              TestingState.up << :irreversible
+            end
+
+            def down
+              raise ActiveRecord::IrreversibleMigration
+            end
+          end
+        RUBY
+      end
+
+      it "keeps track of the irreversible migrations" do
+        utils.prepare_phantom_migrations
+        assert_equal %i[first second irreversible first second irreversible], TestingState.up
+        assert_empty ActualDbSchema.failed
+        utils.simulate_input("y") do
+          Rake::Task["db:rollback_branches:manual"].invoke
+          Rake::Task["db:rollback_branches:manual"].reenable
+        end
+        assert_equal %i[second first second first], TestingState.down
+        failed = ActualDbSchema.failed.map { |m| File.basename(m.filename) }
+        assert_equal(%w[20130906111513_irreversible.rb 20130906111513_irreversible.rb], failed)
+        assert_equal %w[20130906111513_irreversible.rb], utils.migrated_files
+      end
+    end
+  end
+
+  describe "db:phantom_migrations" do
+    it "shows the list of phantom migrations" do
+      ActualDbSchema::Git.stub(:current_branch, "fix-bug") do
+        utils.prepare_phantom_migrations
+        Rake::Task["db:phantom_migrations"].invoke
+        Rake::Task["db:phantom_migrations"].reenable
+        assert_match(/ Status   Migration ID    Branch   Migration File/, TestingState.output)
+        assert_match(/---------------------------------------------------/, TestingState.output)
+        assert_match(%r{   up     20130906111511  fix-bug  tmp/migrated/20130906111511_first.rb}, TestingState.output)
+        assert_match(%r{   up     20130906111512  fix-bug  tmp/migrated/20130906111512_second.rb}, TestingState.output)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/widefix/actual_db_schema/issues/101

### Description
This PR introduces multi-tenancy support enabling schema-specific migrations and rollbacks for applications using PostgreSQL or MySQL.

### Screenshots
#### Success
<img width="661" alt="Screenshot 2024-12-27 at 16 32 24" src="https://github.com/user-attachments/assets/49a2230e-c6a7-4fcb-9085-afe6ef87e68b" />

#### Error
<img width="601" alt="Screenshot 2024-12-27 at 16 31 28" src="https://github.com/user-attachments/assets/e2137bba-b581-4ca1-ba99-53f93609e36c" />

