### PR TITLE
Run the git hook on switch branch only

### DIFF
--- a/lib/actual_db_schema/git_hooks.rb
+++ b/lib/actual_db_schema/git_hooks.rb
@@ -15,6 +15,11 @@ module ActualDbSchema
       # ActualDbSchema post-checkout hook (ROLLBACK)
       # Runs db:rollback_branches on branch checkout.
 
+      # Check if this is a file checkout or creating a new branch
+      if [ "$3" == "0" ] || [ "$1" == "$2" ]; then
+        exit 0
+      fi
+
       if [ -f ./bin/rails ]; then
         if [ -n "$ACTUAL_DB_SCHEMA_GIT_HOOKS_ENABLED" ]; then
           GIT_HOOKS_ENABLED="$ACTUAL_DB_SCHEMA_GIT_HOOKS_ENABLED"
@@ -33,6 +38,11 @@ module ActualDbSchema
       #{POST_CHECKOUT_MARKER_START}
       # ActualDbSchema post-checkout hook (MIGRATE)
       # Runs db:migrate on branch checkout.
+
+      # Check if this is a file checkout or creating a new branch
+      if [ "$3" == "0" ] || [ "$1" == "$2" ]; then
+        exit 0
+      fi
 
       if [ -f ./bin/rails ]; then
         if [ -n "$ACTUAL_DB_SCHEMA_GIT_HOOKS_ENABLED" ]; then


### PR DESCRIPTION
Closes https://github.com/widefix/actual_db_schema/issues/117

### Description
This PR updates the `post-checkout` hook logic to ensure it only runs during branch switches, avoiding execution during file resets or new branch creation. 