### PR TITLE
Fix Logger Dependency Issue in Tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+require "logger"
 require "rails/all"
 require "actual_db_schema"
 require "minitest/autorun"


### PR DESCRIPTION
`concurrent-ruby` v1.3.5 removed the dependency on logger, which caused an error when running tests. This fix explicitly requires Logger to ensure compatibility.