### PR TITLE
Fix schema diff

### DIFF
--- a/app/controllers/actual_db_schema/schema_controller.rb
+++ b/app/controllers/actual_db_schema/schema_controller.rb
@@ -11,7 +11,7 @@ module ActualDbSchema
     private
 
     helper_method def schema_diff_html
-      schema_diff = ActualDbSchema::SchemaDiffHtml.new("db/schema.rb", "db/migrate")
+      schema_diff = ActualDbSchema::SchemaDiffHtml.new("./db/schema.rb", "db/migrate")
       schema_diff.render_html(params[:table])
     end
   end

--- a/lib/tasks/actual_db_schema.rake
+++ b/lib/tasks/actual_db_schema.rake
@@ -56,7 +56,7 @@ namespace :actual_db_schema do # rubocop:disable Metrics/BlockLength
 
   desc "Show the schema.rb diff annotated with the migrations that made the changes"
   task :diff_schema_with_migrations, %i[schema_path migrations_path] => :environment do |_, args|
-    schema_path = args[:schema_path] || "db/schema.rb"
+    schema_path = args[:schema_path] || "./db/schema.rb"
     migrations_path = args[:migrations_path] || "db/migrate"
 
     schema_diff = ActualDbSchema::SchemaDiff.new(schema_path, migrations_path)


### PR DESCRIPTION
Closes https://github.com/widefix/actual_db_schema/issues/133

### Description
The schema diff was not working correctly in a monorepo because of `git show HEAD:db/schema.rb`. 
This PR updates it to use `./db/schema.rb`, ensuring it works correctly when executed inside a subproject directory.