### PR TITLE
Add rake task to delete broken migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,49 @@ remove_index :users, :email
 rename_column :users, :username, :handle
 ```
 
+## Delete Broken Migrations
+
+A migration is considered broken if it has been migrated in the database but the corresponding migration file is missing. This functionality allows you to safely delete these broken versions from the database to keep it clean.
+
+You can delete broken migrations using either of the following methods:
+
+### 1. Using the UI
+
+Navigate to the following URL in your web browser:
+```
+http://localhost:3000/rails/broken_versions
+```
+
+This page lists all broken versions and provides an option to delete them.
+
+### 2. Using a Rake Task
+
+To delete all broken migrations, run:
+```sh
+rake actual_db_schema:delete_broken_versions
+```
+
+To delete specific migrations, pass the migration version(s) and optionally a database:
+```sh
+rake actual_db_schema:delete_broken_versions[<version>, <version>]
+```
+
+- `<version>` – The migration version(s) to delete (space-separated if multiple).
+- `<database>` (optional) – Specify a database if using multiple databases.
+
+#### Examples:
+
+```sh
+# Delete all broken migrations
+rake actual_db_schema:delete_broken_versions
+
+# Delete specific migrations
+rake actual_db_schema:delete_broken_versions["20250224103352 20250224103358"]
+
+# Delete specific migrations from a specific database
+rake actual_db_schema:delete_broken_versions["20250224103352 20250224103358", "primary"]
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/test/rake_task_delete_broken_versions_test.rb
+++ b/test/rake_task_delete_broken_versions_test.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "actual_db_schema:delete_broken_versions" do
+  let(:utils) do
+    TestUtils.new(
+      migrations_path: ["db/migrate", "db/migrate_secondary"],
+      migrated_path: ["tmp/migrated", "tmp/migrated_migrate_secondary"]
+    )
+  end
+
+  before do
+    utils.reset_database_yml(TestingState.db_config)
+    ActiveRecord::Base.configurations = { "test" => TestingState.db_config }
+    ActiveRecord::Tasks::DatabaseTasks.database_configuration = { "test" => TestingState.db_config }
+    utils.cleanup(TestingState.db_config)
+    utils.run_migrations
+  end
+
+  def delete_migration_files
+    utils.remove_app_dir(Rails.root.join("db", "migrate", "20130906111511_first_primary.rb"))
+    utils.remove_app_dir(Rails.root.join("db", "migrate_secondary", "20130906111514_first_secondary.rb"))
+    utils.remove_app_dir(Rails.root.join("tmp", "migrated", "20130906111511_first_primary.rb"))
+    utils.remove_app_dir(Rails.root.join("tmp", "migrated_migrate_secondary", "20130906111514_first_secondary.rb"))
+  end
+
+  describe "when versions are provided" do
+    before { delete_migration_files }
+
+    it "deletes the specified broken migrations" do
+      sql = "SELECT COUNT(*) FROM schema_migrations"
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      Rake::Task["actual_db_schema:delete_broken_versions"].invoke("20130906111511 20130906111514")
+      Rake::Task["actual_db_schema:delete_broken_versions"].reenable
+      assert_match(/\[ActualDbSchema\] Migration 20130906111511 was successfully deleted./, TestingState.output)
+      assert_match(/\[ActualDbSchema\] Migration 20130906111514 was successfully deleted./, TestingState.output)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 1, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 1, ActiveRecord::Base.connection.select_value(sql)
+    end
+
+    it "deletes broken migrations only from the given database when specified" do
+      sql = "SELECT COUNT(*) FROM schema_migrations"
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      Rake::Task["actual_db_schema:delete_broken_versions"]
+        .invoke("20130906111511 20130906111514", TestingState.db_config["primary"]["database"])
+      Rake::Task["actual_db_schema:delete_broken_versions"].reenable
+      assert_match(/\[ActualDbSchema\] Migration 20130906111511 was successfully deleted./, TestingState.output)
+      assert_match(
+        /\[ActualDbSchema\] Error deleting version 20130906111514: Migration is not broken for database #{TestingState.db_config["primary"]["database"]}./, # rubocop:disable Layout/LineLength
+        TestingState.output
+      )
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 1, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+    end
+
+    it "prints an error message when the passed version is not broken" do
+      Rake::Task["actual_db_schema:delete_broken_versions"].invoke("20130906111512")
+      Rake::Task["actual_db_schema:delete_broken_versions"].reenable
+      assert_match(
+        /\[ActualDbSchema\] Error deleting version 20130906111512: Migration is not broken./, TestingState.output
+      )
+    end
+  end
+
+  describe "when no versions are provided" do
+    before { delete_migration_files }
+
+    it "deletes all broken migrations" do
+      delete_migration_files
+      sql = "SELECT COUNT(*) FROM schema_migrations"
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      Rake::Task["actual_db_schema:delete_broken_versions"].invoke
+      Rake::Task["actual_db_schema:delete_broken_versions"].reenable
+      assert_match(/\[ActualDbSchema\] All broken versions were successfully deleted./, TestingState.output)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 1, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 1, ActiveRecord::Base.connection.select_value(sql)
+    end
+
+    it "prints an error message if there is an error during deletion" do
+      original_delete_all = ActualDbSchema::Migration.instance_method(:delete_all)
+      ActualDbSchema::Migration.define_method(:delete_all) do
+        raise StandardError, "Deletion error"
+      end
+      Rake::Task["actual_db_schema:delete_broken_versions"].invoke
+      Rake::Task["actual_db_schema:delete_broken_versions"].reenable
+      assert_match(/\[ActualDbSchema\] Error deleting all broken versions: Deletion error/, TestingState.output)
+      sql = "SELECT COUNT(*) FROM schema_migrations"
+      ActiveRecord::Base.establish_connection(TestingState.db_config["primary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      ActiveRecord::Base.establish_connection(TestingState.db_config["secondary"])
+      assert_equal 2, ActiveRecord::Base.connection.select_value(sql)
+      ActualDbSchema::Migration.define_method(:delete_all, original_delete_all)
+    end
+  end
+
+  describe "when there are no broken versions" do
+    it "prints a message indicating no broken versions found" do
+      Rake::Task["actual_db_schema:delete_broken_versions"].invoke
+      Rake::Task["actual_db_schema:delete_broken_versions"].reenable
+      assert_match(/No broken versions found/, TestingState.output)
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/widefix/actual_db_schema/issues/91

### Description
This PR introduces a new rake task to delete broken migrations from the database.
- If no arguments are passed, it will delete all broken migrations.
- If specific versions and a database are provided, it will delete only those migrations.