### PR TITLE
Skip initializer if `ActualDbSchema` is undefined

### DIFF
--- a/lib/generators/actual_db_schema/templates/actual_db_schema.rb
+++ b/lib/generators/actual_db_schema/templates/actual_db_schema.rb
@@ -3,29 +3,31 @@
 # ActualDbSchema initializer
 # Adjust the configuration as needed.
 
-ActualDbSchema.configure do |config|
-  # Enable the gem.
-  config.enabled = Rails.env.development?
+if defined?(ActualDbSchema)
+  ActualDbSchema.configure do |config|
+    # Enable the gem.
+    config.enabled = Rails.env.development?
 
-  # Disable automatic rollback of phantom migrations.
-  # config.auto_rollback_disabled = true
-  config.auto_rollback_disabled = ENV["ACTUAL_DB_SCHEMA_AUTO_ROLLBACK_DISABLED"].present?
+    # Disable automatic rollback of phantom migrations.
+    # config.auto_rollback_disabled = true
+    config.auto_rollback_disabled = ENV["ACTUAL_DB_SCHEMA_AUTO_ROLLBACK_DISABLED"].present?
 
-  # Enable the UI for managing migrations.
-  config.ui_enabled = Rails.env.development? || ENV["ACTUAL_DB_SCHEMA_UI_ENABLED"].present?
+    # Enable the UI for managing migrations.
+    config.ui_enabled = Rails.env.development? || ENV["ACTUAL_DB_SCHEMA_UI_ENABLED"].present?
 
-  # Enable automatic phantom migration rollback on branch switch,
-  # config.git_hooks_enabled = true
-  config.git_hooks_enabled = ENV["ACTUAL_DB_SCHEMA_GIT_HOOKS_ENABLED"].present?
+    # Enable automatic phantom migration rollback on branch switch,
+    # config.git_hooks_enabled = true
+    config.git_hooks_enabled = ENV["ACTUAL_DB_SCHEMA_GIT_HOOKS_ENABLED"].present?
 
-  # If your application leverages multiple schemas for multi-tenancy, define the active schemas.
-  # config.multi_tenant_schemas = -> { ["public", "tenant1", "tenant2"] }
+    # If your application leverages multiple schemas for multi-tenancy, define the active schemas.
+    # config.multi_tenant_schemas = -> { ["public", "tenant1", "tenant2"] }
 
-  # Enable console migrations.
-  # config.console_migrations_enabled = true
-  config.console_migrations_enabled = ENV["ACTUAL_DB_SCHEMA_CONSOLE_MIGRATIONS_ENABLED"].present?
+    # Enable console migrations.
+    # config.console_migrations_enabled = true
+    config.console_migrations_enabled = ENV["ACTUAL_DB_SCHEMA_CONSOLE_MIGRATIONS_ENABLED"].present?
 
-  # Define the migrated folder location.
-  # config.migrated_folder = Rails.root.join("custom", "migrated")
-  config.migrated_folder = Rails.root.join("tmp", "migrated")
+    # Define the migrated folder location.
+    # config.migrated_folder = Rails.root.join("custom", "migrated")
+    config.migrated_folder = Rails.root.join("tmp", "migrated")
+  end
 end


### PR DESCRIPTION
It is [recommended](https://github.com/widefix/actual_db_schema#installation) to add `actual_db_schema` to the `development` group of your Gemfile. This means that Rails will only `require "actual_db_schema"` when RAILS_ENV is development.

Since initializers run regardless of the Rails environment, the default initializer template causes a `NameError` in non-development environments (the gem is not required and thus the constant is not defined).

```
NameError: uninitialized constant ActualDbSchema (NameError)

  ActualDbSchema.configure do |config|
  ^^^^^^^^^^^^^^
```

To fix this, we only run the ActualDbSchema configure block when `ActualDbSchema` is defined.