### PR TITLE
Switch from parser to prism

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ PATH
       ast
       csv
       parser
+      prism
 
 GEM
   remote: https://rubygems.org/
@@ -145,6 +146,7 @@ GEM
     parser (3.2.2.4)
       ast (~> 2.4.1)
       racc
+    prism (1.4.0)
     psych (5.1.1.1)
       stringio
     racc (1.7.3)

--- a/actual_db_schema.gemspec
+++ b/actual_db_schema.gemspec
@@ -40,6 +40,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "ast"
   spec.add_runtime_dependency "csv"
   spec.add_runtime_dependency "parser"
+  spec.add_runtime_dependency "prism"
 
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "debug"

--- a/lib/actual_db_schema/migration_parser.rb
+++ b/lib/actual_db_schema/migration_parser.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "parser/current"
 require "ast"
+require "prism"
 
 module ActualDbSchema
   # Parses migration files in a Rails application into a structured hash representation.
@@ -41,9 +41,7 @@ module ActualDbSchema
     private
 
     def parse_file(file_path)
-      buffer = Parser::Source::Buffer.new(file_path)
-      buffer.source = File.read(file_path, encoding: "UTF-8")
-      Parser::CurrentRuby.parse(buffer.source)
+      Prism::Translation::Parser.parse_file(file_path)
     end
 
     def find_migration_changes(node)

--- a/lib/actual_db_schema/schema_parser.rb
+++ b/lib/actual_db_schema/schema_parser.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require "parser/current"
 require "parser/ast/processor"
+require "prism"
 
 module ActualDbSchema
   # Parses the content of a `schema.rb` file into a structured hash representation.
@@ -9,10 +9,7 @@ module ActualDbSchema
     module_function
 
     def parse_string(schema_content)
-      buffer = Parser::Source::Buffer.new("(schema)")
-      buffer.source = schema_content
-      parser = Parser::CurrentRuby.new
-      ast = parser.parse(buffer)
+      ast = Prism::Translation::Parser.parse(schema_content)
 
       collector = SchemaCollector.new
       collector.process(ast)


### PR DESCRIPTION
Closes https://github.com/widefix/actual_db_schema/issues/150

### Description
Since the parser gem doesn't support Ruby versions starting from 3.4, this PR updates `MigrationParser` and `SchemaParser` to use the Prism translation parser instead. However, the parser gem is not removed because the AST processing code still depends on `Parser::AST::Processor`.
