### PR TITLE
Bugfix: Restore original connection after iterating through connections

### DIFF
--- a/lib/actual_db_schema/migration_context.rb
+++ b/lib/actual_db_schema/migration_context.rb
@@ -23,8 +23,11 @@ module ActualDbSchema
     end
 
     def current_config
-      pool = ActiveRecord::Base.connection_pool
-      pool.respond_to?(:db_config) ? pool.db_config : pool.spec.config
+      if ActiveRecord::Base.respond_to?(:connection_db_config)
+        ActiveRecord::Base.connection_db_config
+      else
+        ActiveRecord::Base.connection_config
+      end
     end
 
     def configs

--- a/lib/actual_db_schema/migration_context.rb
+++ b/lib/actual_db_schema/migration_context.rb
@@ -6,10 +6,13 @@ module ActualDbSchema
     include Singleton
 
     def each
+      original_config = current_config
       configs.each do |db_config|
         establish_connection(db_config)
         yield context
       end
+    ensure
+      establish_connection(original_config) if original_config
     end
 
     private
@@ -17,6 +20,11 @@ module ActualDbSchema
     def establish_connection(db_config)
       config = db_config.respond_to?(:config) ? db_config.config : db_config
       ActiveRecord::Base.establish_connection(config)
+    end
+
+    def current_config
+      pool = ActiveRecord::Base.connection_pool
+      pool.respond_to?(:db_config) ? pool.db_config : pool.spec.config
     end
 
     def configs

--- a/test/test_migration_context.rb
+++ b/test/test_migration_context.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+describe "ActualDbSchema::MigrationContext#each" do
+  let(:utils) do
+    TestUtils.new(
+      migrations_path: ["db/migrate", "db/migrate_secondary"],
+      migrated_path: ["tmp/migrated", "tmp/migrated_migrate_secondary"]
+    )
+  end
+
+  before do
+    utils.reset_database_yml(TestingState.db_config)
+    ActiveRecord::Base.configurations = { "test" => TestingState.db_config }
+    ActiveRecord::Tasks::DatabaseTasks.database_configuration = { "test" => TestingState.db_config }
+    utils.cleanup(TestingState.db_config)
+    # Establish connection to primary as the "original" connection before iterating
+    ActiveRecord::Base.establish_connection(**TestingState.db_config["primary"])
+  end
+
+  it "restores the original connection after iterating over multiple databases" do
+    primary_db = File.basename(TestingState.db_config["primary"]["database"])
+
+    # Iterating switches the connection to each database in turn (primary, then secondary)
+    ActualDbSchema::MigrationContext.instance.each { |_context| }
+
+    # After iteration, the connection must be restored to the original (primary) database.
+    # Without restoration, the connection is left on the last database (secondary), which
+    # means any subsequent ActiveRecord queries silently hit the wrong database.
+    current_db = File.basename(current_database)
+    assert_equal primary_db, current_db,
+      "MigrationContext#each must restore the original connection after iteration, " \
+      "but was left on '#{current_db}' instead of '#{primary_db}'"
+  end
+
+  private
+
+  def current_database
+    if ActiveRecord::Base.respond_to?(:connection_db_config)
+      ActiveRecord::Base.connection_db_config.database
+    else
+      ActiveRecord::Base.connection_config[:database]
+    end
+  end
+end


### PR DESCRIPTION
We use multiple databases. I experienced an error after installing this gem where our application was attempting to fetch data from a table in the incorrect database. I believe it is due to the original connection not getting restored in the `each` method in MigrationContext. I've tested this in my application with a monkeypatch.