### PR TITLE
Allow accessing /rails/ when there are pending migrations

### DIFF
--- a/lib/actual_db_schema.rb
+++ b/lib/actual_db_schema.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "actual_db_schema/middlewares/skip_pending_migration_check"
 require "actual_db_schema/engine"
 require "active_record/migration"
 require "csv"
@@ -14,6 +15,7 @@ require_relative "actual_db_schema/failed_migration"
 require_relative "actual_db_schema/migration_context"
 require_relative "actual_db_schema/migration_parser"
 require_relative "actual_db_schema/output_formatter"
+require_relative "actual_db_schema/patches/check_pending"
 require_relative "actual_db_schema/patches/migration_proxy"
 require_relative "actual_db_schema/patches/migrator"
 require_relative "actual_db_schema/patches/migration_context"

--- a/lib/actual_db_schema/engine.rb
+++ b/lib/actual_db_schema/engine.rb
@@ -10,6 +10,13 @@ module ActualDbSchema
         app.routes.append do
           mount ActualDbSchema::Engine => "/rails"
         end
+
+        ActiveRecord::Migration::CheckPending.prepend(ActualDbSchema::Patches::CheckPending)
+
+        app.middleware.insert_before(
+          ActiveRecord::Migration::CheckPending,
+          ActualDbSchema::Middlewares::SkipPendingMigrationCheck
+        )
       end
     end
 

--- a/lib/actual_db_schema/middlewares/skip_pending_migration_check.rb
+++ b/lib/actual_db_schema/middlewares/skip_pending_migration_check.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module ActualDbSchema
+  module Middlewares
+    # Middleware that skips the pending migration check for ActualDbSchema UI routes.
+    # This allows accessing /rails/ paths even when there are pending migrations.
+    class SkipPendingMigrationCheck
+      def initialize(app)
+        @app = app
+      end
+
+      def call(env)
+        if actual_db_schema_path?(env["PATH_INFO"], env["REQUEST_METHOD"])
+          env["actual_db_schema.skip_pending_check"] = true
+        end
+        @app.call(env)
+      end
+
+      private
+
+      def actual_db_schema_path?(path, method)
+        return false unless path.start_with?(engine_mount_path)
+
+        ActualDbSchema::Engine.routes.recognize_path(
+          path.sub(engine_mount_path, "") || "/",
+          method: method
+        )
+
+        true
+      rescue ActionController::RoutingError
+        false
+      end
+
+      def engine_mount_path
+        @engine_mount_path ||= ActualDbSchema::Engine.routes.find_script_name({})
+      end
+    end
+  end
+end

--- a/lib/actual_db_schema/patches/check_pending.rb
+++ b/lib/actual_db_schema/patches/check_pending.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActualDbSchema
+  module Patches
+    # Patches Rails' CheckPending middleware to skip the pending
+    # migration check for ActualDbSchema UI routes (/rails/).
+    module CheckPending
+      def call(env)
+        return @app.call(env) if env["actual_db_schema.skip_pending_check"]
+
+        super
+      end
+    end
+  end
+end

--- a/test/middlewares/skip_pending_migration_check_test.rb
+++ b/test/middlewares/skip_pending_migration_check_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require_relative "../test_helper"
+
+module ActualDbSchema
+  module Middlewares
+    class SkipPendingMigrationCheckTest < ActiveSupport::TestCase
+      test "sets flag for /rails/ subpaths and skips pending migration check" do
+        [
+          { "PATH_INFO" => "/rails/migrations", "REQUEST_METHOD" => "GET" },
+          { "PATH_INFO" => "/rails/phantom_migrations", "REQUEST_METHOD" => "GET" },
+          { "PATH_INFO" => "/rails/schema", "REQUEST_METHOD" => "GET" },
+          { "PATH_INFO" => "/rails/broken_versions", "REQUEST_METHOD" => "GET" },
+          { "PATH_INFO" => "/rails/migrations/123/migrate", "REQUEST_METHOD" => "POST" },
+          { "PATH_INFO" => "/rails/migrations/123/rollback", "REQUEST_METHOD" => "POST" }
+        ].each do |env|
+          ActualDbSchema::Engine.routes.stub(:recognize_path, { controller: "test", action: "index" }) do
+            SkipPendingMigrationCheck.new(check_pending_app).call(env)
+            assert env["actual_db_schema.skip_pending_check"], "Expected flag for #{env["PATH_INFO"]}"
+          end
+        end
+      end
+
+      test "does not set flag and raises PendingMigrationError for non-engine paths" do
+        %w[/ /some/other/path /rails_fake /railsmigrations].each do |path|
+          env = { "PATH_INFO" => path, "REQUEST_METHOD" => "GET" }
+          ActualDbSchema::Engine.routes.stub(:recognize_path,
+                                             proc { raise ActionController::RoutingError, "No route" }) do
+            assert_raises ActiveRecord::PendingMigrationError do
+              SkipPendingMigrationCheck.new(check_pending_app).call(env)
+            end
+            assert_nil env["actual_db_schema.skip_pending_check"], "Expected no flag for #{path}"
+          end
+        end
+      end
+
+      private
+
+      def check_pending_app
+        lambda do |env|
+          raise ActiveRecord::PendingMigrationError unless env["actual_db_schema.skip_pending_check"]
+
+          [200, {}, []]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Root Cause**

When there are pending migrations, Rails' `CheckPending` middleware raises `ActiveRecord::PendingMigrationError` for every request, including `/rails/migrations`. This does not allow users to access `/rails/path` pages.

**Implementation**

Added a `SkipPendingMigrationCheck` middleware that sets a flag in the request env for any `/rails/ path`. Then prepended `Patches::CheckPending` into `ActiveRecord::Migration::CheckPending` to skip the pending check when that flag is present. The middleware is inserted before `CheckPending` in the stack so the flag is always set before the check runs.